### PR TITLE
Remove duplicate theme export

### DIFF
--- a/packages/core/src/theme/index.ts
+++ b/packages/core/src/theme/index.ts
@@ -3,6 +3,5 @@ export * from './defaultTheme/index';
 export * from './defaultTokens/index';
 export * from './provideTheme/index';
 export * from './provideTokens/index';
-export * from './provideTokens/index';
 export * from './useTheme/index';
 export * from './useTokens/index';


### PR DESCRIPTION
## Summary
- fix duplicated export in `packages/core/src/theme/index.ts`

## Testing
- `npm run lint` *(fails: turbo not found)*
- `npm test` *(fails: jest not found)*


------
https://chatgpt.com/codex/tasks/task_e_686e9b92c3608321a0e8625168fe3187